### PR TITLE
Avoid cumulative layout shift

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -44,6 +44,7 @@
   top: 0;
   line-height: normal;
   font-size: 100%;
+  max-height: 100%;
 
   --exposure: 50%;
   --transition-time: 0ms;


### PR DESCRIPTION
I used two images that have the same dimensions : 1920x1080. But I still have a cls because the block .first has more height than the images does and so does the handle. To resolve this I set max-height: 100%;