### PR TITLE
non-passive event listener touchstart

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,9 @@ export class HTMLImgComparisonSliderElement extends HTMLElement {
     this.addEventListener('keyup', this.onKeyUp);
     this.addEventListener('focus', this.onFocus);
     this.addEventListener('blur', this.onBlur);
-    this.addEventListener('touchstart', this.onTouchStart);
+    this.addEventListener('touchstart', this.onTouchStart, {
+      passive: true,
+    });
     this.addEventListener('touchmove', this.onTouchMove, {
       passive: false,
     });


### PR DESCRIPTION
Hello, is it possible to make this eventlistener passive ? Chromium doesn't like it and since you don't use preventDefault for this listener it should be fine.

It's coming from this line https://github.com/sneas/img-comparison-slider/blob/797fbbce36640d38400499fa6ff3c8ae20f8cadc/src/index.ts#L86

![Screenshot from 2021-07-30 18-24-39](https://user-images.githubusercontent.com/15686636/127682902-abbe3b59-bc24-4363-beb1-704a69cff0ea.png)

https://www.chromestatus.com/feature/5745543795965952