### PR TITLE
Add `keyboard` attribute for toggling keyboard controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Usage examples: [https://img-comparison-slider.sneas.io/examples.html](https://i
 
 ### Browser Requirements
 
-- Support for [ECMAScript 2015 (ES6)](https://caniuse.com/?search=es6). Use [Babel](https://babeljs.io/docs/en/babel-preset-env) if needed. 
+- Support for [ECMAScript 2015 (ES6)](https://caniuse.com/?search=es6). Use [Babel](https://babeljs.io/docs/en/babel-preset-env) if needed.
 - Support for [Custom Elements (V1)](https://caniuse.com/?search=custom%20elements%20v1) and [ShadowDOM (V1)](https://caniuse.com/?search=shadowdom%20v1). Use [Polyfills](https://www.webcomponents.org/polyfills) if support for older browsers is needed.
 - Support for [CSS Variables (Custom Properties)](https://caniuse.com/?search=css%20custom%20properties). [Polyfill](https://github.com/nuxodin/ie11CustomProperties) it for IE11.
 
@@ -77,12 +77,13 @@ Usage examples: [https://img-comparison-slider.sneas.io/examples.html](https://i
 
 Besides the default `HTMLElement` attributes such as `class`, `tabindex`, `title`, etc., `img-comparison-slider` supports:
 
-| Attribute   | Description                                     | Default      | Available              |
-| ----------- | ----------------------------------------------- | ------------ | ---------------------- |
-| `value`     | Position of the divider in percents.            | `50`         | `0..100`               |
-| `hover`     | Automatically slide on mouse over.              | `false`      |                        |
-| `direction` | Set slider direction.                           | `horizontal` | `horizontal, vertical` |
-| `nonce`     | Define nonce which gets passed to inline style. |              |                        |
+| Attribute   | Description                                               | Default      | Available                |
+| ----------- | --------------------------------------------------------- | ------------ | ------------------------ |
+| `value`     | Position of the divider in percents.                      | `50`         | `0..100`                 |
+| `hover`     | Automatically slide on mouse over.                        | `false`      |                          |
+| `direction` | Set slider direction.                                     | `horizontal` | `horizontal`, `vertical` |
+| `nonce`     | Define nonce which gets passed to inline style.           |              |                          |
+| `keyboard`  | Enable/disable slider position control with the keyboard. | `enabled`    | `enabled`, `disabled`    |
 
 ## Events
 

--- a/bindings/react/src/index.tsx
+++ b/bindings/react/src/index.tsx
@@ -20,6 +20,7 @@ type ImgComparisonSliderProps =
     value?: number | string;
     hover?: boolean;
     direction?: string;
+    keyboard?: 'enabled' | 'disabled';
     onSlide?: ChangeEventHandler<HTMLImgComparisonSliderElement>;
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ const KeySlideOffset: Record<SlideKey, number> = {
 };
 
 type SlideDirection = 'horizontal' | 'vertical';
+type KeyboardMode = 'enabled' | 'disabled';
 
 const slideDirections: Array<SlideDirection> = ['horizontal', 'vertical'];
 
@@ -48,7 +49,7 @@ export class HTMLImgComparisonSliderElement extends HTMLElement {
   private slideOnHover = false;
   private slideDirection: SlideDirection = 'horizontal';
 
-  private keyboard = 'enabled';
+  private keyboard: KeyboardMode = 'enabled';
 
   private isMouseDown = false;
 
@@ -144,9 +145,8 @@ export class HTMLImgComparisonSliderElement extends HTMLElement {
 
     this.setExposure(0);
 
-    this.keyboard = this.hasAttribute('keyboard')
-      ? this.getAttribute('keyboard')
-      : 'enabled';
+    this.keyboard = this.hasAttribute('keyboard') &&
+					  this.getAttribute('keyboard') === 'disabled' ? 'disabled' : 'enabled';
 
     if (this.keyboard !== 'disabled') {
       this.addEventListener('keydown', this.onKeyDown);

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,8 @@ export class HTMLImgComparisonSliderElement extends HTMLElement {
   private slideOnHover = false;
   private slideDirection: SlideDirection = 'horizontal';
 
+  private keyboard = 'enabled';
+
   private isMouseDown = false;
 
   private isAnimating: boolean;
@@ -142,8 +144,15 @@ export class HTMLImgComparisonSliderElement extends HTMLElement {
 
     this.setExposure(0);
 
-    this.addEventListener('keydown', this.onKeyDown);
-    this.addEventListener('keyup', this.onKeyUp);
+    this.keyboard = this.hasAttribute('keyboard')
+      ? this.getAttribute('keyboard')
+      : 'enabled';
+
+    if (this.keyboard !== 'disabled') {
+      this.addEventListener('keydown', this.onKeyDown);
+      this.addEventListener('keyup', this.onKeyUp);
+    }
+
     this.addEventListener('focus', this.onFocus);
     this.addEventListener('blur', this.onBlur);
     this.addEventListener('touchstart', this.onTouchStart, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,10 +151,8 @@ export class HTMLImgComparisonSliderElement extends HTMLElement {
         ? 'disabled'
         : 'enabled';
 
-    if (this.keyboard !== 'disabled') {
-      this.addEventListener('keydown', this.onKeyDown);
-      this.addEventListener('keyup', this.onKeyUp);
-    }
+    this.addEventListener('keydown', this.onKeyDown);
+    this.addEventListener('keyup', this.onKeyUp);
 
     this.addEventListener('focus', this.onFocus);
     this.addEventListener('blur', this.onBlur);
@@ -318,6 +316,10 @@ export class HTMLImgComparisonSliderElement extends HTMLElement {
   };
 
   private onKeyDown = (e: KeyboardEvent) => {
+    if (this.keyboard === 'disabled') {
+      return;
+    }
+
     if (this.isAnimating) {
       return;
     }
@@ -334,6 +336,10 @@ export class HTMLImgComparisonSliderElement extends HTMLElement {
   };
 
   private onKeyUp = (e: KeyboardEvent) => {
+    if (this.keyboard === 'disabled') {
+      return;
+    }
+
     if (!this.isAnimating) {
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,8 +145,11 @@ export class HTMLImgComparisonSliderElement extends HTMLElement {
 
     this.setExposure(0);
 
-    this.keyboard = this.hasAttribute('keyboard') &&
-					  this.getAttribute('keyboard') === 'disabled' ? 'disabled' : 'enabled';
+    this.keyboard =
+      this.hasAttribute('keyboard') &&
+      this.getAttribute('keyboard') === 'disabled'
+        ? 'disabled'
+        : 'enabled';
 
     if (this.keyboard !== 'disabled') {
       this.addEventListener('keydown', this.onKeyDown);
@@ -199,6 +202,10 @@ export class HTMLImgComparisonSliderElement extends HTMLElement {
 
     if (name === 'direction') {
       this.direction = newValue;
+    }
+
+    if (name === 'keyboard') {
+      this.keyboard = newValue === 'disabled' ? 'disabled' : 'enabled';
     }
   }
 


### PR DESCRIPTION
This PR adds a `keyboard` attribute for toggling the keyboard controls (`enabled` (default) or `disabled` to disable keyboard controls).
For using other elements than `<img>` inside the `img-comparison-slider` component, the keyboard functionality may interfere (by unintentionally changing the divider and/or catching the keyboard events from the elements inside).

```html
<img-comparison-slider keyboard="disabled">
  <!-- [...] -->
</img-comparison-slider>
````