### PR TITLE
fix(react): remove classname attibute from web-component

### DIFF
--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -34,16 +34,18 @@ export const ImgComparisonSlider: FC<ImgComparisonSliderProps> = forwardRef(
     {
       children,
       onSlide,
+      value,
+      className,
       ...props
     }: PropsWithChildren<ImgComparisonSliderProps>,
     ref: ForwardedRef<HTMLImgComparisonSliderElement>
   ) => {
     const sliderRef = useRef<HTMLImgComparisonSliderElement>();
     useEffect(() => {
-      if (props.value !== undefined) {
-        sliderRef.current.value = parseFloat(props.value.toString());
+      if (value !== undefined) {
+        sliderRef.current.value = parseFloat(value.toString());
       }
-    }, [props.value, sliderRef]);
+    }, [value, sliderRef]);
 
     useEffect(() => {
       if (onSlide) {
@@ -58,7 +60,7 @@ export const ImgComparisonSlider: FC<ImgComparisonSliderProps> = forwardRef(
       'img-comparison-slider',
       Object.assign(
         {
-          class: props.className ? `${props.className} rendered` : 'rendered',
+          class: className ? `${className} rendered` : 'rendered',
           // Align tabIndex between the web and React components
           // this code could be removed when
           // https://github.com/WICG/webcomponents/issues/762 is resolved.


### PR DESCRIPTION
Hello @sneas , thank you for creating the @img-comparation-slider/react. While using it, I noticed that there was a superfluous 'classname' attribute in the HTML. This PR is to remove the redundant 'classname' attribute.

before
![image](https://github.com/sneas/img-comparison-slider/assets/31569789/a0478115-d6a2-4440-866a-8a1eb1552c5d)

now 
![image](https://github.com/sneas/img-comparison-slider/assets/31569789/22a5e093-b05d-4672-a633-4d46cdaef8d5)
