### PR TITLE
Use Constructable Stylesheets instead of style element with nonce

### DIFF
--- a/packages/img-comparison-slider/README.md
+++ b/packages/img-comparison-slider/README.md
@@ -83,7 +83,6 @@ Besides the default `HTMLElement` attributes such as `class`, `tabindex`, `title
 | `value`     | Position of the divider in percents.                      | `50`         | `0..100`                 |
 | `hover`     | Automatically slide on mouse over.                        | `false`      |                          |
 | `direction` | Set slider direction.                                     | `horizontal` | `horizontal`, `vertical` |
-| `nonce`     | Define nonce which gets passed to inline style.           |              |                          |
 | `keyboard`  | Enable/disable slider position control with the keyboard. | `enabled`    | `enabled`, `disabled`    |
 | `handle`    | Enable/disable dragging by handle only.                   | `false`      | `true`, `false`          |
 

--- a/packages/img-comparison-slider/src/declarations.d.ts
+++ b/packages/img-comparison-slider/src/declarations.d.ts
@@ -1,2 +1,16 @@
 declare module '*.scss';
 declare module '*.html';
+
+// Constructable Stylesheets API
+interface CSSStyleSheet {
+  replaceSync(text: string): void;
+  replace(text: string): Promise<CSSStyleSheet>;
+}
+
+interface ShadowRoot {
+  adoptedStyleSheets: CSSStyleSheet[];
+}
+
+interface Document {
+  adoptedStyleSheets: CSSStyleSheet[];
+}

--- a/packages/img-comparison-slider/src/index.ts
+++ b/packages/img-comparison-slider/src/index.ts
@@ -124,13 +124,9 @@ export class HTMLImgComparisonSliderElement extends HTMLElement {
 
     const shadowRoot = this.attachShadow({ mode: 'open' });
 
-    const styleEl = document.createElement('style');
-    styleEl.innerHTML = styles;
-
-    if (this.getAttribute('nonce')) {
-      styleEl.setAttribute('nonce', this.getAttribute('nonce'));
-    }
-    shadowRoot.appendChild(styleEl);
+    const sheet = new CSSStyleSheet();
+    sheet.replaceSync(styles);
+    shadowRoot.adoptedStyleSheets = [sheet];
 
     shadowRoot.appendChild(templateElement.content.cloneNode(true));
 


### PR DESCRIPTION
This fixes CSP nonce issues with Shadow DOM. The nonce attribute cannot be reliably transferred to dynamically created style elements inside Shadow DOM. Constructable Stylesheets bypass this problem entirely.